### PR TITLE
Disable route metrics when `enableRouteMetrics: false`

### DIFF
--- a/src/__tests__/no_route_metrics.spec.ts
+++ b/src/__tests__/no_route_metrics.spec.ts
@@ -1,0 +1,50 @@
+import fastifyPlugin = require('../index');
+import fastify from 'fastify';
+
+const app = fastify();
+
+// Add a couple of routes to test
+app.get('/test', async () => {
+  return 'get test';
+});
+app.post('/test', async () => {
+  return 'post test';
+});
+
+beforeAll(async () => {
+  await app.register(fastifyPlugin, {
+    endpoint: '/metrics',
+    enableRouteMetrics: false,
+  });
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+describe('metrics plugin', () => {
+  afterEach(async () => {
+    // Reset metrics after each test
+    app.metrics.client.register.resetMetrics();
+  });
+
+  it('should not register route metrics when enableRouteMetrics is false', async () => {
+    await app.inject({
+      method: 'GET',
+      url: '/test',
+    });
+
+    await app.inject({
+      method: 'POST',
+      url: '/test',
+    });
+
+    const metrics = await app.inject({
+      method: 'GET',
+      url: '/metrics',
+    });
+
+    expect(metrics.payload).toContain('');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,24 +125,6 @@ const fastifyMetricsPlugin: FastifyPlugin<PluginOptions> = async function fastif
     const routeHist = new client.Histogram(opts.histogram);
     const routeSum = new client.Summary(opts.summary);
 
-    if (endpoint) {
-      fastify.route({
-        url: endpoint,
-        method: 'GET',
-        schema: {
-          // hide route from swagger plugins
-          hide: true,
-        },
-        handler: (_, reply) => {
-          const data = register
-            ? register.metrics()
-            : client.register.metrics();
-
-          void reply.type('text/plain').send(data);
-        },
-      });
-    }
-
     fastify.addHook('onRequest', (request, _, next) => {
       if (request.raw.url && collectMetricsForUrl(request.raw.url)) {
         request.metrics = {
@@ -179,6 +161,22 @@ const fastifyMetricsPlugin: FastifyPlugin<PluginOptions> = async function fastif
         });
       }
       next();
+    });
+  }
+
+  if (endpoint) {
+    fastify.route({
+      url: endpoint,
+      method: 'GET',
+      schema: {
+        // hide route from swagger plugins
+        hide: true,
+      },
+      handler: (_, reply) => {
+        const data = register ? register.metrics() : client.register.metrics();
+
+        void reply.type('text/plain').send(data);
+      },
     });
   }
 


### PR DESCRIPTION
The `if (enableRouteMetrics)` was wrapping the whole plugin,
now it's a toggle to specifically enable/disable the route metrics (histogram and summary).

Despite that, the default metrics provide by prom-client will gonna still working.

Solved [#15](https://github.com/SkeLLLa/fastify-metrics/issues/15)