### PR TITLE
Update prom-client to ^13.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8772,9 +8772,9 @@
       "dev": true
     },
     "prom-client": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-12.0.0.tgz",
-      "integrity": "sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-13.1.0.tgz",
+      "integrity": "sha512-jT9VccZCWrJWXdyEtQddCDszYsiuWj5T0ekrPszi/WEegj3IZy6Mm09iOOVM86A4IKMWq8hZkT2dD9MaSe+sng==",
       "requires": {
         "tdigest": "^0.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "fastify-plugin": "^3.0.0",
-    "prom-client": "^12.0.0"
+    "prom-client": "^13.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,10 +172,10 @@ const fastifyMetricsPlugin: FastifyPlugin<PluginOptions> = async function fastif
         // hide route from swagger plugins
         hide: true,
       },
-      handler: (_, reply) => {
+      handler: async (_, reply) => {
         const data = register ? register.metrics() : client.register.metrics();
 
-        void reply.type('text/plain').send(data);
+        void reply.type('text/plain').send(await data);
       },
     });
   }


### PR DESCRIPTION
This PR updates the version of prom-client to 13.0.0.

Closes #21.

I've marked it as a breaking change as users may have to adjust their usage of `fastify.metrics.client`.