### PR TITLE
Add invalid routes group

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ You may create your metrics when app starts and store it in `fastify.metrics` ob
 | `metrics`              | Object                   | Allows override default metrics config. See section below.                                            | `{}`        |
 | `blacklist`            | String, RegExp, String[] | Skip metrics collection for blacklisted routes                                                        | `undefined` |
 | `groupStatusCodes`     | Boolean                  | Groups status codes (e.g. 2XX) if `true`                                                              | `false`     |
+| `invalidRouteGroup`    | String                   | If set, group any urls not matching a valid fastify route together rather than report individually.   | `undefined` |
 
 #### Metrics details
 

--- a/src/__tests__/group_invalid_routes_metrics.spec.ts
+++ b/src/__tests__/group_invalid_routes_metrics.spec.ts
@@ -1,0 +1,132 @@
+import fastifyPlugin = require('../index');
+import fastify from 'fastify';
+
+const app = fastify();
+
+// Add a couple of routes to test
+app.get('/test', async () => {
+  return 'get test';
+});
+app.post('/test', async () => {
+  return 'post test';
+});
+
+beforeAll(async () => {
+  await app.register(fastifyPlugin, {
+    endpoint: '/metrics',
+    invalidRouteGroup: 'INVALID_GROUP',
+  });
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+describe('metrics plugin', () => {
+  afterEach(async () => {
+    // Reset metrics after each test
+    app.metrics.client.register.resetMetrics();
+  });
+
+  it('should register default metrics', async () => {
+    await app.inject({
+      method: 'GET',
+      url: '/test',
+    });
+
+    await app.inject({
+      method: 'POST',
+      url: '/test',
+    });
+
+    const metrics = await app.inject({
+      method: 'GET',
+      url: '/metrics',
+    });
+
+    expect(metrics.payload).toContain(
+      '# HELP http_request_duration_seconds request duration in seconds'
+    );
+    expect(metrics.payload).toContain(
+      '# TYPE http_request_duration_seconds histogram'
+    );
+    expect(metrics.payload).toContain(
+      'http_request_duration_seconds_bucket{le="0.05",method="GET",route="/test",status_code="200"}'
+    );
+    expect(metrics.payload).toContain(
+      'http_request_duration_seconds_sum{method="GET",route="/test",status_code="200"}'
+    );
+    expect(metrics.payload).toContain(
+      'http_request_duration_seconds_count{method="GET",route="/test",status_code="200"}'
+    );
+    expect(metrics.payload).toContain(
+      'http_request_duration_seconds_bucket{le="0.05",method="POST",route="/test",status_code="200"}'
+    );
+    expect(metrics.payload).toContain(
+      'http_request_duration_seconds_sum{method="POST",route="/test",status_code="200"}'
+    );
+    expect(metrics.payload).toContain(
+      'http_request_duration_seconds_count{method="POST",route="/test",status_code="200"}'
+    );
+    expect(metrics.payload).toContain(
+      '# HELP http_request_summary_seconds request duration in seconds summary'
+    );
+    expect(metrics.payload).toContain(
+      '# TYPE http_request_summary_seconds summary'
+    );
+    expect(metrics.payload).toContain(
+      'http_request_summary_seconds{quantile="0.5",method="GET",route="/test",status_code="200"'
+    );
+    expect(metrics.payload).toContain(
+      'http_request_summary_seconds{quantile="0.5",method="GET",route="/test",status_code="200"'
+    );
+  });
+
+  it('should group unrecognised routes', async () => {
+    await app.inject({
+      method: 'GET',
+      url: '/not-exists',
+    });
+    await app.inject({
+      method: 'GET',
+      url: '/not-exists-2',
+    });
+
+    const metrics = await app.inject({
+      method: 'GET',
+      url: '/metrics',
+    });
+
+    expect(metrics.payload).toContain(
+      '# HELP http_request_duration_seconds request duration in seconds'
+    );
+    expect(metrics.payload).toContain(
+      '# TYPE http_request_duration_seconds histogram'
+    );
+    expect(metrics.payload).toContain(
+      'http_request_duration_seconds_bucket{le="0.05",method="GET",route="INVALID_GROUP",status_code="404"}'
+    );
+    expect(metrics.payload).toContain(
+      'http_request_duration_seconds_sum{method="GET",route="INVALID_GROUP",status_code="404"}'
+    );
+    expect(metrics.payload).toContain(
+      'http_request_duration_seconds_count{method="GET",route="INVALID_GROUP",status_code="404"}'
+    );
+    expect(metrics.payload).toContain(
+      '# HELP http_request_summary_seconds request duration in seconds summary'
+    );
+    expect(metrics.payload).toContain(
+      '# TYPE http_request_summary_seconds summary'
+    );
+    expect(metrics.payload).toContain(
+      'http_request_summary_seconds{quantile="0.5",method="GET",route="INVALID_GROUP",status_code="404"'
+    );
+    expect(metrics.payload).toContain(
+      'http_request_summary_seconds{quantile="0.5",method="GET",route="INVALID_GROUP",status_code="404"'
+    );
+    expect(metrics.payload).toContain(
+      'http_request_summary_seconds_count{method="GET",route="INVALID_GROUP",status_code="404"} 2'
+    );
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ const fastifyMetricsPlugin: FastifyPlugin<PluginOptions> = async function fastif
     enableRouteMetrics = true,
     groupStatusCodes = false,
     pluginName = 'metrics',
+    invalidRouteGroup,
     blacklist,
     register,
     prefix,
@@ -140,10 +141,11 @@ const fastifyMetricsPlugin: FastifyPlugin<PluginOptions> = async function fastif
         const context: FastifyContext<MetricsContextConfig> = reply.context as FastifyContext<
           MetricsContextConfig
         >;
-        let routeId = context.config.url || request.raw.url;
-        if (context.config.statsId) {
-          routeId = context.config.statsId;
-        }
+        const routeId =
+          context.config.statsId ||
+          context.config.url ||
+          invalidRouteGroup ||
+          request.raw.url;
         const method = request.raw.method;
         const statusCode = groupStatusCodes
           ? `${Math.floor(reply.raw.statusCode / 100)}xx`

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -52,6 +52,10 @@ export interface PluginOptions {
    */
   groupStatusCodes?: boolean;
   /**
+   * Groups urls that are not mapped onto valid routes together
+   */
+  invalidRouteGroup?: string;
+  /**
    * Plugin name that will be registered in fastify
    * @default metrics
    */


### PR DESCRIPTION
Adding direct support into the fastify-metrics module to support grouping of urls that are not mapped to valid fastify routes together.

Although this is achievable with a custom request hook to set the "context.config.statsId" dependent on match, it's not quite as obvious.

The primary reason for this is that when services are probed for weaknesses we ended up with hundreds of single-entry prometheus entries which led to increased response times for prometheus and reduced value (as more often that not we are not interested in these points).