### PR TITLE
Set plugin name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,8 @@ export default fastifyPlugin<IMetricsPluginOptions>(
 
     const fm = new FastifyMetrics({ client, fastify, options });
     fastify.decorate<IFastifyMetrics>(name, fm);
-  },
-
-  '>=4.0.0'
+  }, {
+    fastify: '>=4.0.0',
+    name: 'metrics',
+  }
 );


### PR DESCRIPTION
Without this option it is registered under name "index"