### PR TITLE
merge metrics in endpoint

### DIFF
--- a/src/fastify-metrics.ts
+++ b/src/fastify-metrics.ts
@@ -150,18 +150,17 @@ export class FastifyMetrics {
     const defaultRegistries = this.getCustomDefaultMetricsRegistries();
     const routeRegistries = this.getCustomRouteMetricsRegistries();
 
-    const merged = this.deps.client.Registry.merge([
-      globalRegistry,
-      ...defaultRegistries,
-      ...routeRegistries,
-    ]);
-
     this.deps.fastify.route({
       url: endpoint ?? '/metrics',
       method: 'GET',
       logLevel: 'fatal',
       exposeHeadRoute: false,
       handler: async (_, reply) => {
+        const merged = this.deps.client.Registry.merge([
+          globalRegistry,
+          ...defaultRegistries,
+          ...routeRegistries,
+        ]);
         const data = await merged.metrics();
         return reply.type('text/plain').send(data);
       },


### PR DESCRIPTION
Account to prom-client source code Registry.merge function copies list of metrics in a new registry. If someone adds metric after module initialization, it will not be in the endpoint.
Example:

```javascript
app1.register(metricsPlugin, {
        routeMetrics: {
            overrides: {
                histogram: {
                    registers: [ registry ],
                },
                summary: {
                    registers: [ registry ]
                }
            }
        },
        endpoint: null,
    })
app2.register(metricsPlugin, {
        routeMetrics: {
            overrides: {
                histogram: {
                    registers: [ registry ],
                },
                summary: {
                    registers: [ registry ]
                }
            }
        },
        endpoint: null,
    })
```

Before: /metrics endpoint in app1 includes metrics from app1, /metrics in app2 includes metrics both from app1 and app2
After: /metrics endpoint in app1 and app2 include metrics from app1 and app2