### PR TITLE
fix(metrics): add initMetricsInRegistry method

### DIFF
--- a/src/__tests__/default-metrics.spec.ts
+++ b/src/__tests__/default-metrics.spec.ts
@@ -1,7 +1,7 @@
 import {
   afterAll,
   afterEach,
-  beforeAll,
+  beforeEach,
   describe,
   expect,
   test,
@@ -16,9 +16,10 @@ describe('default metrics', () => {
   });
 
   describe('{ }', () => {
-    const app = fastify();
+    let app = fastify();
 
-    beforeAll(async () => {
+    beforeEach(async () => {
+      app = fastify();
       await app.register(fastifyPlugin, {
         endpoint: '/metrics',
         defaultMetrics: {
@@ -56,9 +57,11 @@ describe('default metrics', () => {
   });
 
   describe('{ enabled = true; register = new Registry() }', () => {
-    const app = fastify();
+    let app = fastify();
 
-    beforeAll(async () => {
+    beforeEach(async () => {
+      app = fastify();
+
       await app.register(fastifyPlugin, {
         endpoint: '/metrics',
         defaultMetrics: {
@@ -72,7 +75,7 @@ describe('default metrics', () => {
       await app.ready();
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await app.close();
     });
 
@@ -97,9 +100,11 @@ describe('default metrics', () => {
   });
 
   describe('{ enabled = true; endoint = null }', () => {
-    const app = fastify();
+    let app = fastify();
 
-    beforeAll(async () => {
+    beforeEach(async () => {
+      app = fastify();
+
       await app.register(fastifyPlugin, {
         endpoint: null,
         defaultMetrics: {
@@ -112,7 +117,7 @@ describe('default metrics', () => {
       await app.ready();
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await app.close();
     });
 
@@ -145,9 +150,11 @@ describe('default metrics', () => {
   });
 
   describe('{ enabled = false }', () => {
-    const app = fastify();
+    let app = fastify();
 
-    beforeAll(async () => {
+    beforeEach(async () => {
+      app = fastify();
+
       await app.register(fastifyPlugin, {
         endpoint: '/metrics',
         defaultMetrics: {
@@ -160,7 +167,7 @@ describe('default metrics', () => {
       await app.ready();
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await app.close();
     });
 

--- a/src/__tests__/edge-cases.spec.ts
+++ b/src/__tests__/edge-cases.spec.ts
@@ -1,0 +1,106 @@
+import {
+  afterAll,
+  beforeAll,
+  afterEach,
+  describe,
+  expect,
+  test,
+} from '@jest/globals';
+import fastify from 'fastify';
+import promClient from 'prom-client';
+import fastifyPlugin from '..';
+
+describe('edge cases', () => {
+  afterEach(() => {
+    promClient.register.clear();
+  });
+
+  describe('registry clear problem', () => {
+    const app = fastify();
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    beforeAll(async () => {
+      await app.register(fastifyPlugin, {
+        endpoint: '/metrics',
+      });
+      app.get('/test', async () => {
+        return 'get test';
+      });
+      await app.ready();
+    });
+
+    test('metrics are initialized after register clear call', async () => {
+      await expect(
+        app.inject({
+          method: 'GET',
+          url: '/test',
+        })
+      ).resolves.toBeDefined();
+
+      const metrics = await app.inject({
+        method: 'GET',
+        url: '/metrics',
+      });
+
+      expect(typeof metrics.payload).toBe('string');
+
+      const lines = metrics.payload.split('\n');
+
+      expect(lines).toEqual(
+        expect.arrayContaining([
+          'http_request_duration_seconds_count{method="GET",route="/test",status_code="200"} 1',
+          'http_request_summary_seconds_count{method="GET",route="/test",status_code="200"} 1',
+        ])
+      );
+
+      app.metrics.client.register.clear();
+
+      await expect(
+        app.inject({
+          method: 'GET',
+          url: '/test',
+        })
+      ).resolves.toBeDefined();
+
+      const metricsAfterClear = await app.inject({
+        method: 'GET',
+        url: '/metrics',
+      });
+
+      expect(typeof metricsAfterClear.payload).toBe('string');
+
+      const linesAfterClear = metricsAfterClear.payload.split('\n');
+
+      expect(linesAfterClear).toEqual(['', '']);
+
+      // Reinit metrics in registry
+      app.metrics.initMetricsInRegistry();
+
+      await expect(
+        app.inject({
+          method: 'GET',
+          url: '/test',
+        })
+      ).resolves.toBeDefined();
+
+      const metricsAfterReinit = await app.inject({
+        method: 'GET',
+        url: '/metrics',
+      });
+
+      expect(typeof metricsAfterReinit.payload).toBe('string');
+
+      // const linesAfterReinit = metricsAfterReinit.payload.split('\n');
+
+      // expect(linesAfterReinit).toEqual(
+      //   expect.arrayContaining([
+      //     'http_request_duration_seconds_count{method="GET",route="/test",status_code="200"} 1',
+      //     'http_request_summary_seconds_count{method="GET",route="/test",status_code="200"} 1',
+      //   ])
+      // );
+    });
+  });
+});

--- a/src/__tests__/route-metrics.spec.ts
+++ b/src/__tests__/route-metrics.spec.ts
@@ -1,11 +1,4 @@
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  describe,
-  expect,
-  test,
-} from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
 import fastify from 'fastify';
 import promClient from 'prom-client';
 import fastifyPlugin from '../';
@@ -16,13 +9,14 @@ describe('route metrics', () => {
   });
 
   describe('{ }', () => {
-    const app = fastify();
+    let app = fastify();
 
-    afterAll(async () => {
+    afterEach(async () => {
       await app.close();
     });
 
-    beforeAll(async () => {
+    beforeEach(async () => {
+      app = fastify();
       await app.register(fastifyPlugin, {
         endpoint: '/metrics',
       });
@@ -125,7 +119,7 @@ describe('route metrics', () => {
       );
     });
 
-    test('metrics not exposed with custom route name in config', async () => {
+    test('metrics exposed with custom route name in config', async () => {
       await expect(
         app.inject({
           method: 'GET',
@@ -152,13 +146,15 @@ describe('route metrics', () => {
   });
 
   describe('{ enabled = false }', () => {
-    const app = fastify();
+    let app = fastify();
 
-    afterAll(async () => {
+    afterEach(async () => {
       await app.close();
     });
 
-    beforeAll(async () => {
+    beforeEach(async () => {
+      app = fastify();
+
       await app.register(fastifyPlugin, {
         endpoint: '/metrics',
         routeMetrics: {
@@ -210,13 +206,15 @@ describe('route metrics', () => {
   });
 
   describe('{ registeredRoutesOnly = false }', () => {
-    const app = fastify();
+    let app = fastify();
 
-    afterAll(async () => {
+    afterEach(async () => {
       await app.close();
     });
 
-    beforeAll(async () => {
+    beforeEach(async () => {
+      app = fastify();
+
       await app.register(fastifyPlugin, {
         endpoint: '/metrics',
         routeMetrics: {
@@ -268,13 +266,15 @@ describe('route metrics', () => {
   });
 
   describe(`{ registeredRoutesOnly = false, invalidRouteGroup = 'foo' }`, () => {
-    const app = fastify();
+    let app = fastify();
 
-    afterAll(async () => {
+    afterEach(async () => {
       await app.close();
     });
 
-    beforeAll(async () => {
+    beforeEach(async () => {
+      app = fastify();
+
       await app.register(fastifyPlugin, {
         endpoint: '/metrics',
         routeMetrics: {
@@ -327,13 +327,15 @@ describe('route metrics', () => {
   });
 
   describe(`{ routeBlacklist = ['/test'] }`, () => {
-    const app = fastify();
+    let app = fastify();
 
-    afterAll(async () => {
+    afterEach(async () => {
       await app.close();
     });
 
-    beforeAll(async () => {
+    beforeEach(async () => {
+      app = fastify();
+
       await app.register(fastifyPlugin, {
         endpoint: '/metrics',
         routeMetrics: {
@@ -390,13 +392,15 @@ describe('route metrics', () => {
   });
 
   describe(`{ methodBlacklist = ['GET'] }`, () => {
-    const app = fastify();
+    let app = fastify();
 
-    afterAll(async () => {
+    afterEach(async () => {
       await app.close();
     });
 
-    beforeAll(async () => {
+    beforeEach(async () => {
+      app = fastify();
+
       await app.register(fastifyPlugin, {
         endpoint: '/metrics',
         routeMetrics: {
@@ -450,13 +454,15 @@ describe('route metrics', () => {
   });
 
   describe(`{ groupStatusCodes = true }`, () => {
-    const app = fastify();
+    let app = fastify();
 
-    afterAll(async () => {
+    afterEach(async () => {
       await app.close();
     });
 
-    beforeAll(async () => {
+    beforeEach(async () => {
+      app = fastify();
+
       await app.register(fastifyPlugin, {
         endpoint: '/metrics',
         routeMetrics: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -224,5 +224,11 @@ export interface IMetricsPluginOptions {
  * @public
  */
 export interface IFastifyMetrics {
+  /** Prom-client instance */
   client: typeof client;
+  /**
+   * Initialize metrics in registries. Useful if you call `registry.clear()` to
+   * register metrics in regisitries once again
+   */
+  initMetricsInRegistry(): void;
 }


### PR DESCRIPTION
initMetricsInRegistry allows to register route metrics once again after
registry clear


includes fixes from: #52 