### PR TITLE
docs: fix typo of registering the plugin example

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ export * from './types';
  *     const options: IMetricsPluginOptions = { endpoint: '/metrics' }
  *     fastify()
  *      .register(fastifyMetrics, options)
- *      .get('/foo, (request, reply) => {
+ *      .get('/foo', (request, reply) => {
  *         reply.code(200);
  *         const delay = Math.random() * 10000;
  *         setTimeout(() => {


### PR DESCRIPTION
There is a missing comma on the route path which is causing the example to not show in tools like VSCode with the proper code coloring.