### PR TITLE
fix: fix routes with array of method

### DIFF
--- a/src/fastify-metrics.ts
+++ b/src/fastify-metrics.ts
@@ -297,7 +297,7 @@ export class FastifyMetrics implements IFastifyMetrics {
         if (
           this.routesWhitelist.has(
             FastifyMetrics.getRouteSlug({
-              method: request.routerMethod,
+              method: request.method,
               url: request.routerPath,
             })
           )
@@ -324,7 +324,7 @@ export class FastifyMetrics implements IFastifyMetrics {
           request.routeConfig.statsId ??
           request.routerPath ??
           this.routeFallback;
-        const method = request.routerMethod ?? request.method;
+        const method = request.method;
 
         const labels = {
           [this.routeMetrics.labelNames.method]: method,


### PR DESCRIPTION
Hi, thanks for ability to use default prom metrics with fastify!

But after some research I was not able to use `registeredRoutesOnly` properly, I have defined graphql endpoint:
```
app.route({
    url: "/graphql",
    method: ["GET", "POST", "OPTIONS"],
    handler: async (req, reply) => {
      const response = await yoga.handleNodeRequest(req, {
        req,
        reply,
      });
      response.headers.forEach((value, key) => {
        reply.header(key, value);
      });

      reply.status(response.status);

      reply.send(response.body);

      return reply;
    },
  });
```

before this fix fastify-metrics produce only metrics for routes that have single method inside `app.route` ie.
```
app.route({
    url: "/test-api",
    method: "GET",
    handler: (req, reply) => {
      reply.send('test');

      return reply;
    },
  });
 ```
Also I think it will be useful to have metrics for different HTTP methods for single route.
WDYT @SkeLLLa about move this small changes behind some boolean inside `routeMetrics` options? 

After fixes I'm able to produce fallowing metrics
```
# HELP http_request_duration_seconds request duration in seconds
# TYPE http_request_duration_seconds histogram
http_request_duration_seconds_bucket{le="0.005",method="GET",route="/metrics",status_code="2xx"} 7
http_request_duration_seconds_bucket{le="0.01",method="GET",route="/metrics",status_code="2xx"} 10
http_request_duration_seconds_bucket{le="0.025",method="GET",route="/metrics",status_code="2xx"} 14
http_request_duration_seconds_bucket{le="0.05",method="GET",route="/metrics",status_code="2xx"} 14
http_request_duration_seconds_bucket{le="0.1",method="GET",route="/metrics",status_code="2xx"} 14
http_request_duration_seconds_bucket{le="0.25",method="GET",route="/metrics",status_code="2xx"} 14
http_request_duration_seconds_bucket{le="0.5",method="GET",route="/metrics",status_code="2xx"} 14
http_request_duration_seconds_bucket{le="1",method="GET",route="/metrics",status_code="2xx"} 14
http_request_duration_seconds_bucket{le="2.5",method="GET",route="/metrics",status_code="2xx"} 14
http_request_duration_seconds_bucket{le="5",method="GET",route="/metrics",status_code="2xx"} 14
http_request_duration_seconds_bucket{le="10",method="GET",route="/metrics",status_code="2xx"} 14
http_request_duration_seconds_bucket{le="+Inf",method="GET",route="/metrics",status_code="2xx"} 14
http_request_duration_seconds_sum{method="GET",route="/metrics",status_code="2xx"} 0.09403808200000001
http_request_duration_seconds_count{method="GET",route="/metrics",status_code="2xx"} 14
http_request_duration_seconds_bucket{le="0.005",method="GET",route="/graphql",status_code="2xx"} 3
http_request_duration_seconds_bucket{le="0.01",method="GET",route="/graphql",status_code="2xx"} 4
http_request_duration_seconds_bucket{le="0.025",method="GET",route="/graphql",status_code="2xx"} 4
http_request_duration_seconds_bucket{le="0.05",method="GET",route="/graphql",status_code="2xx"} 4
http_request_duration_seconds_bucket{le="0.1",method="GET",route="/graphql",status_code="2xx"} 4
http_request_duration_seconds_bucket{le="0.25",method="GET",route="/graphql",status_code="2xx"} 4
http_request_duration_seconds_bucket{le="0.5",method="GET",route="/graphql",status_code="2xx"} 4
http_request_duration_seconds_bucket{le="1",method="GET",route="/graphql",status_code="2xx"} 4
http_request_duration_seconds_bucket{le="2.5",method="GET",route="/graphql",status_code="2xx"} 4
http_request_duration_seconds_bucket{le="5",method="GET",route="/graphql",status_code="2xx"} 4
http_request_duration_seconds_bucket{le="10",method="GET",route="/graphql",status_code="2xx"} 4
http_request_duration_seconds_bucket{le="+Inf",method="GET",route="/graphql",status_code="2xx"} 4
http_request_duration_seconds_sum{method="GET",route="/graphql",status_code="2xx"} 0.015806042
http_request_duration_seconds_count{method="GET",route="/graphql",status_code="2xx"} 4
http_request_duration_seconds_bucket{le="0.005",method="POST",route="/graphql",status_code="2xx"} 3
http_request_duration_seconds_bucket{le="0.01",method="POST",route="/graphql",status_code="2xx"} 6
http_request_duration_seconds_bucket{le="0.025",method="POST",route="/graphql",status_code="2xx"} 9
http_request_duration_seconds_bucket{le="0.05",method="POST",route="/graphql",status_code="2xx"} 9
http_request_duration_seconds_bucket{le="0.1",method="POST",route="/graphql",status_code="2xx"} 9
http_request_duration_seconds_bucket{le="0.25",method="POST",route="/graphql",status_code="2xx"} 9
http_request_duration_seconds_bucket{le="0.5",method="POST",route="/graphql",status_code="2xx"} 9
http_request_duration_seconds_bucket{le="1",method="POST",route="/graphql",status_code="2xx"} 9
http_request_duration_seconds_bucket{le="2.5",method="POST",route="/graphql",status_code="2xx"} 9
http_request_duration_seconds_bucket{le="5",method="POST",route="/graphql",status_code="2xx"} 9
http_request_duration_seconds_bucket{le="10",method="POST",route="/graphql",status_code="2xx"} 9
http_request_duration_seconds_bucket{le="+Inf",method="POST",route="/graphql",status_code="2xx"} 9
http_request_duration_seconds_sum{method="POST",route="/graphql",status_code="2xx"} 0.07122850099999999
http_request_duration_seconds_count{method="POST",route="/graphql",status_code="2xx"} 9

# HELP http_request_summary_seconds request duration in seconds summary
# TYPE http_request_summary_seconds summary
http_request_summary_seconds{quantile="0.01",method="GET",route="/metrics",status_code="2xx"} 0.002540458
http_request_summary_seconds{quantile="0.05",method="GET",route="/metrics",status_code="2xx"} 0.0027484080000000004
http_request_summary_seconds{quantile="0.5",method="GET",route="/metrics",status_code="2xx"} 0.0048041045
http_request_summary_seconds{quantile="0.9",method="GET",route="/metrics",status_code="2xx"} 0.0118518914
http_request_summary_seconds{quantile="0.95",method="GET",route="/metrics",status_code="2xx"} 0.014038050199999997
http_request_summary_seconds{quantile="0.99",method="GET",route="/metrics",status_code="2xx"} 0.014662667
http_request_summary_seconds{quantile="0.999",method="GET",route="/metrics",status_code="2xx"} 0.014662667
http_request_summary_seconds_sum{method="GET",route="/metrics",status_code="2xx"} 0.09277495699999999
http_request_summary_seconds_count{method="GET",route="/metrics",status_code="2xx"} 14
http_request_summary_seconds{quantile="0.01",method="GET",route="/graphql",status_code="2xx"} 0.001853917
http_request_summary_seconds{quantile="0.05",method="GET",route="/graphql",status_code="2xx"} 0.001853917
http_request_summary_seconds{quantile="0.5",method="GET",route="/graphql",status_code="2xx"} 0.0041275205
http_request_summary_seconds{quantile="0.9",method="GET",route="/graphql",status_code="2xx"} 0.005356583
http_request_summary_seconds{quantile="0.95",method="GET",route="/graphql",status_code="2xx"} 0.005356583
http_request_summary_seconds{quantile="0.99",method="GET",route="/graphql",status_code="2xx"} 0.005356583
http_request_summary_seconds{quantile="0.999",method="GET",route="/graphql",status_code="2xx"} 0.005356583
http_request_summary_seconds_sum{method="GET",route="/graphql",status_code="2xx"} 0.015465541
http_request_summary_seconds_count{method="GET",route="/graphql",status_code="2xx"} 4
http_request_summary_seconds{quantile="0.01",method="POST",route="/graphql",status_code="2xx"} 0.002875709
http_request_summary_seconds{quantile="0.05",method="POST",route="/graphql",status_code="2xx"} 0.002875709
http_request_summary_seconds{quantile="0.5",method="POST",route="/graphql",status_code="2xx"} 0.005850125
http_request_summary_seconds{quantile="0.9",method="POST",route="/graphql",status_code="2xx"} 0.0136071752
http_request_summary_seconds{quantile="0.95",method="POST",route="/graphql",status_code="2xx"} 0.013967542
http_request_summary_seconds{quantile="0.99",method="POST",route="/graphql",status_code="2xx"} 0.013967542
http_request_summary_seconds{quantile="0.999",method="POST",route="/graphql",status_code="2xx"} 0.013967542
http_request_summary_seconds_sum{method="POST",route="/graphql",status_code="2xx"} 0.070699917
http_request_summary_seconds_count{method="POST",route="/graphql",status_code="2xx"} 9
```