### PR TITLE
Fix typo/error in Route metrics overrides example

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ const fastify = require('fastify');
 const app = fastify();
 const metricsPlugin = require('fastify-metrics');
 
-await app.register(metricsPlugin, {endpoint: '/metrics', {
+await app.register(metricsPlugin, {
+  endpoint: '/metrics',
   routeMetrics: {
     overrides: {
       histogram: {
@@ -170,7 +171,7 @@ await app.register(metricsPlugin, {endpoint: '/metrics', {
       },
     }
   }
-}});
+});
 ```
 
 ###### Labels


### PR DESCRIPTION
The example of the route metrics override contains the route metrics nested in a new object although it should be a property of the same object the property 'endpoint' belongs to.