### PR TITLE
feat: add option to disable summary collection in routeMetrics config

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ See for details [docs](docs/api/fastify-metrics.imetricspluginoptions.md)
 
 | Property                                                                                    | Type                                                                                          | Default Value                           |
 | ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | --------------------------------------- |
-| [enabled?](./docs/fastify-metrics.iroutemetricsconfig.enabled.md)                           | boolean                                                                                       | `true`                                  |
+| [enabled?](./docs/fastify-metrics.iroutemetricsconfig.enabled.md)                           | boolean \| { histogram: boolean, summary: boolean }                                           | `true`                                  |
 | [enableSummaries?](./docs/fastify-metrics.iroutemetricsconfig.enablesummaries.md)           | boolean                                                                                       | `true`                                  |
 | [groupStatusCodes?](./docs/fastify-metrics.iroutemetricsconfig.groupstatuscodes.md)         | boolean                                                                                       | `false`                                 |
 | [invalidRouteGroup?](./docs/fastify-metrics.iroutemetricsconfig.invalidroutegroup.md)       | string                                                                                        | `'__unknown__'`                         |
@@ -149,6 +149,24 @@ See for details [docs](docs/api/fastify-metrics.imetricspluginoptions.md)
 | [registeredRoutesOnly?](./docs/fastify-metrics.iroutemetricsconfig.registeredroutesonly.md) | boolean                                                                                       | `true`                                  |
 | [customLabels?](./fastify-metrics.iroutemetricsconfig.customlabels.md)                      | Record&lt;string, string \| ((request: FastifyRequest, reply: FastifyReply) =&gt; string)&gt; | `undefined`                             |
 | [routeBlacklist?](./docs/fastify-metrics.iroutemetricsconfig.routeblacklist.md)             | readonly string\[\]                                                                           | `[]`                                    |
+
+#### Route metrics enabled
+
+The `enabled` configuration option can be either a boolean which enables/disables generation of both histograms and summaries, or it can be set to an object that allows you to pick individually whether you want histograms or summaries to be generated, for example:
+
+```
+{
+  ...
+  routeMetrics: {
+    enabled: {
+      histogram: true,
+      summary: false
+    }
+  }
+}
+```
+
+would result in the library only generating histograms.
 
 ##### Route metrics overrides
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ See for details [docs](docs/api/fastify-metrics.imetricspluginoptions.md)
 | Property                                                                                    | Type                                                                                          | Default Value                           |
 | ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | --------------------------------------- |
 | [enabled?](./docs/fastify-metrics.iroutemetricsconfig.enabled.md)                           | boolean                                                                                       | `true`                                  |
+| [enableSummaries?](./docs/fastify-metrics.iroutemetricsconfig.enablesummaries.md)           | boolean                                                                                       | `true`                                  |
 | [groupStatusCodes?](./docs/fastify-metrics.iroutemetricsconfig.groupstatuscodes.md)         | boolean                                                                                       | `false`                                 |
 | [invalidRouteGroup?](./docs/fastify-metrics.iroutemetricsconfig.invalidroutegroup.md)       | string                                                                                        | `'__unknown__'`                         |
 | [methodBlacklist?](./docs/fastify-metrics.iroutemetricsconfig.methodblacklist.md)           | readonly string\[\]                                                                           | `['HEAD','OPTIONS','TRACE','CONNECT',]` |
@@ -205,7 +206,7 @@ await app.register(metricsPlugin, {
 
 ### HTTP routes metrics in Prometheus
 
-The following table shows what metrics will be available in Prometheus. Note suffixes like `_bucket`, `_sum`, `_count` are added automatically.
+The following table shows what metrics will be available in Prometheus. Note suffixes like `_bucket`, `_sum`, `_count` are added automatically and `summary` type metrics will only be available if `{ routeMetrics: { enableSummaries: true } }`
 
 | metric                                 | labels                           | description                   |
 | -------------------------------------- | -------------------------------- | ----------------------------- |

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ await app.register(metricsPlugin, {
 
 ### HTTP routes metrics in Prometheus
 
-The following table shows what metrics will be available in Prometheus. Note suffixes like `_bucket`, `_sum`, `_count` are added automatically and `summary` type metrics will only be available if `{ routeMetrics: { enableSummaries: true } }`
+The following table shows what metrics will be available in Prometheus (subject to the `enabled` configuration option). Note suffixes like `_bucket`, `_sum`, `_count` are added automatically.
 
 | metric                                 | labels                           | description                   |
 | -------------------------------------- | -------------------------------- | ----------------------------- |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "fastify-metrics",
-  "version": "10.3.3",
+  "version": "10.4.0",
   "description": "Prometheus metrics exporter for Fastify",
   "keywords": [
     "fastify-plugin",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "fastify-metrics",
-  "version": "10.4.0",
+  "version": "10.3.3",
   "description": "Prometheus metrics exporter for Fastify",
   "keywords": [
     "fastify-plugin",

--- a/src/__tests__/route-metrics.spec.ts
+++ b/src/__tests__/route-metrics.spec.ts
@@ -626,4 +626,61 @@ describe('route metrics', () => {
       );
     });
   });
+
+  describe(`{ routeMetrics: { enableSummaries: false } }`, () => {
+    let app = fastify();
+
+    afterEach(async () => {
+      await app.close();
+    });
+
+    beforeEach(async () => {
+      app = fastify();
+
+      await app.register(fastifyPlugin, {
+        endpoint: '/metrics',
+        routeMetrics: {
+          enabled: true,
+          enableSummaries: false,
+          customLabels: {
+            url: (request: FastifyRequest) => request.url,
+          },
+        },
+      });
+      app.get('*', async (_request, reply) => {
+        await reply.send('foo');
+      });
+      await app.ready();
+    });
+
+    test('summaries are not collected', async () => {
+      await expect(
+        app.inject({
+          method: 'GET',
+          url: '/test',
+        })
+      ).resolves.toBeDefined();
+
+      const metrics = await app.inject({
+        method: 'GET',
+        url: '/metrics',
+      });
+
+      expect(typeof metrics.payload).toBe('string');
+
+      const lines = metrics.payload.split('\n');
+
+      expect(lines).toEqual(
+        expect.arrayContaining([
+          'http_request_duration_seconds_count{method="GET",route="*",status_code="200",url="/test"} 1',
+        ])
+      );
+
+      expect(lines).toEqual(
+        expect.not.arrayContaining([
+          'http_request_summary_seconds_count{method="GET",route="*",status_code="200",url="/test"} 1',
+        ])
+      );
+    });
+  });
 });

--- a/src/__tests__/route-metrics.spec.ts
+++ b/src/__tests__/route-metrics.spec.ts
@@ -627,7 +627,7 @@ describe('route metrics', () => {
     });
   });
 
-  describe(`{ routeMetrics: { enableSummaries: false } }`, () => {
+  describe(`{ routeMetrics: { enable: { summary: false } } }`, () => {
     let app = fastify();
 
     afterEach(async () => {
@@ -640,8 +640,9 @@ describe('route metrics', () => {
       await app.register(fastifyPlugin, {
         endpoint: '/metrics',
         routeMetrics: {
-          enabled: true,
-          enableSummaries: false,
+          enabled: {
+            summary: false,
+          },
           customLabels: {
             url: (request: FastifyRequest) => request.url,
           },

--- a/src/fastify-metrics.ts
+++ b/src/fastify-metrics.ts
@@ -42,6 +42,7 @@ export const DEFAULT_OPTIONS: IMetricsPluginOptions = {
   clearRegisterOnInit: false,
   routeMetrics: {
     enabled: true,
+    enableSummaries: true,
   },
   defaultMetrics: {
     enabled: true,
@@ -352,7 +353,9 @@ export class FastifyMetrics implements IFastifyMetrics {
           [this.routeMetrics.labelNames.status]: statusCode,
           ...this.collectCustomLabels(request, reply),
         };
-        metrics.sum(labels);
+        if (!(this.options.routeMetrics.enableSummaries === false)) {
+          metrics.sum(labels);
+        }
         metrics.hist(labels);
 
         done();

--- a/src/fastify-metrics.ts
+++ b/src/fastify-metrics.ts
@@ -108,7 +108,7 @@ export class FastifyMetrics implements IFastifyMetrics {
   }
   /** Populates methods blacklist to exclude them from metrics collection */
   private setMethodBlacklist(): void {
-    if (this.options.routeMetrics.enabled === undefined) {
+    if (this.options.routeMetrics.enabled === false) {
       return;
     }
 
@@ -127,7 +127,7 @@ export class FastifyMetrics implements IFastifyMetrics {
   /** Populates routes whitelist if */
   private setRouteWhitelist(): void {
     if (
-      this.options.routeMetrics.enabled === undefined ||
+      this.options.routeMetrics.enabled === false ||
       this.options.routeMetrics.registeredRoutesOnly === false
     ) {
       return;
@@ -182,7 +182,7 @@ export class FastifyMetrics implements IFastifyMetrics {
    */
   private getCustomRouteMetricsRegistries(): Registry[] {
     const { routeMetrics } = this.options;
-    if (routeMetrics.enabled === undefined) {
+    if (routeMetrics.enabled === false) {
       return [];
     }
     return [
@@ -398,7 +398,7 @@ export class FastifyMetrics implements IFastifyMetrics {
     if (!(this.options.defaultMetrics.enabled === false)) {
       this.collectDefaultMetrics();
     }
-    if (!(this.options.routeMetrics.enabled === undefined)) {
+    if (!(this.options.routeMetrics.enabled === false)) {
       this.routeMetrics = this.registerRouteMetrics();
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -158,9 +158,16 @@ export interface IRouteMetricsConfig {
   /**
    * Enables collection of fastify routes metrics response time.
    *
-   * @defaultValue `false`
+   * @defaultValue `true`
    */
   enabled?: boolean;
+
+  /**
+   * Enables computation of summaries for response times.
+   *
+   * @defaultValue 'true'
+   */
+  enableSummaries?: boolean;
 
   /**
    * Collect metrics only for registered routes. If `false`, then metrics for

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,19 +155,24 @@ export interface IRouteMetricsOverrides {
  * @public
  */
 export interface IRouteMetricsConfig {
-  /**
-   * Enables collection of fastify routes metrics response time.
-   *
-   * @defaultValue `true`
-   */
-  enabled?: boolean;
-
-  /**
-   * Enables computation of summaries for response times.
-   *
-   * @defaultValue 'true'
-   */
-  enableSummaries?: boolean;
+  enabled?:
+    | boolean
+    | {
+        /**
+         * Enables collection of fastify routes metrics response time via
+         * histogram.
+         *
+         * @defaultValue `true`
+         */
+        histogram?: boolean;
+        /**
+         * Enables collection of fastify routes metrics response time via
+         * summary.
+         *
+         * @defaultValue `true`
+         */
+        summary?: boolean;
+      };
 
   /**
    * Collect metrics only for registered routes. If `false`, then metrics for


### PR DESCRIPTION
As you might know, quantiles can be calculated server-side from histograms using Prometheus' `histogram_quantile` function. There are numerous reasons for doing this over summaries:
- Summaries are computationally expensive, hence put strain on the client.
- Summaries cannot be aggregated.

This library is great, and it's been very useful for my personal use-cases, but I've found that I'm using `histogram_quantile` and completely ignoring summaries, yet they are still getting calculated and there is no option to disable them.

Please consider my PR and let me know if I need to make any changes :).