### PR TITLE
Update prom-client to v15.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -133,8 +133,7 @@ See for details [docs](docs/api/fastify-metrics.imetricspluginoptions.md)
 | [endpoint?](./docs/api/fastify-metrics.imetricspluginoptions.endpoint.md)             | string \| null \| [`Fastify.RouteOptions`](https://www.fastify.io/docs/api/latest/Reference/Routes/#routes-options) | `'/metrics'`        |
 | [name?](./docs/api/fastify-metrics.imetricspluginoptions.name.md)                     | string                                                                                                              | `'metrics'`         |
 | [routeMetrics?](./docs/api/fastify-metrics.imetricspluginoptions.routemetrics.md)     | [IRouteMetricsConfig](./docs/api/fastify-metrics.iroutemetricsconfig.md)                                            | `{ enabled: true }` |
-| [promClient?](./docs/api/fastify-metrics.imetricspluginoptions.promclient.md)         | `prom-client` instance \| null                                                                                                    | `null`              |
-
+| [promClient?](./docs/api/fastify-metrics.imetricspluginoptions.promclient.md)         | `prom-client` instance \| null                                                                                      | `null`              |
 
 #### Route metrics
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ pnpm i fastify-metrics --save
 ---
 
 - Requires fastify `>=4.0.0`.
-- Node.js `>=16.0.0`.
+- Node.js `>=18.0.0`.
 
 <sub>[Back to top](#toc)</sub>
 

--- a/docs/api/fastify-metrics.idefaultmetricsconfig.md
+++ b/docs/api/fastify-metrics.idefaultmetricsconfig.md
@@ -9,10 +9,10 @@ Default prom-client metrics config
 <b>Signature:</b>
 
 ```typescript
-export interface IDefaultMetricsConfig extends DefaultMetricsCollectorConfiguration
+export interface IDefaultMetricsConfig extends DefaultMetricsCollectorConfiguration<'text/plain; version=0.0.4; charset=utf-8'>
 ```
 
-<b>Extends:</b> DefaultMetricsCollectorConfiguration
+<b>Extends:</b> DefaultMetricsCollectorConfiguration&lt;'text/plain; version=0.0.4; charset=utf-8'&gt;
 
 ## Remarks
 

--- a/etc/fastify-metrics.api.md
+++ b/etc/fastify-metrics.api.md
@@ -27,7 +27,7 @@ export default _default;
 
 // @public
 export interface IDefaultMetricsConfig
-  extends DefaultMetricsCollectorConfiguration {
+  extends DefaultMetricsCollectorConfiguration<'text/plain; version=0.0.4; charset=utf-8'> {
   enabled: boolean;
 }
 

--- a/etc/fastify-metrics.api.md
+++ b/etc/fastify-metrics.api.md
@@ -51,6 +51,7 @@ export interface IMetricsPluginOptions {
   defaultMetrics: IDefaultMetricsConfig;
   endpoint: string | null | RouteOptions;
   name: string;
+  promClient: typeof client | null;
   routeMetrics: IRouteMetricsConfig;
 }
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "fastify-plugin": "^4.3.0",
-    "prom-client": "^14.2.0"
+    "prom-client": "^15.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^4.3.0
     version: 4.3.0
   prom-client:
-    specifier: ^14.2.0
-    version: 14.2.0
+    specifier: ^15.1.0
+    version: 15.1.0
 
 devDependencies:
   '@commitlint/cli':
@@ -1241,6 +1241,11 @@ packages:
     dependencies:
       '@octokit/openapi-types': 16.0.0
     dev: true
+
+  /@opentelemetry/api@1.8.0:
+    resolution: {integrity: sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==}
+    engines: {node: '>=8.0.0'}
+    dev: false
 
   /@pnpm/config.env-replace@1.1.0:
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -5606,10 +5611,11 @@ packages:
     engines: {node: '>= 0.6.0'}
     dev: true
 
-  /prom-client@14.2.0:
-    resolution: {integrity: sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==}
-    engines: {node: '>=10'}
+  /prom-client@15.1.0:
+    resolution: {integrity: sha512-cCD7jLTqyPdjEPBo/Xk4Iu8jxjuZgZJ3e/oET3L+ZwOuap/7Cw3dH/TJSsZKs1TQLZ2IHpIlRAKw82ef06kmMw==}
+    engines: {node: ^16 || ^18 || >=20}
     dependencies:
+      '@opentelemetry/api': 1.8.0
       tdigest: 0.1.2
     dev: false
 

--- a/src/__tests__/edge-cases.spec.ts
+++ b/src/__tests__/edge-cases.spec.ts
@@ -144,7 +144,7 @@ describe('edge cases', () => {
           expect.stringMatching(
             /process_cpu_user_seconds_total\{foo="bar"\} \d+/
           ),
-          'http_request_duration_seconds_count{method="GET",route="/test",status_code="200",foo="bar"} 1',
+          'http_request_duration_seconds_count{foo="bar",method="GET",route="/test",status_code="200"} 1',
           'http_request_summary_seconds_count{method="GET",route="/test",status_code="200",foo="bar"} 1',
         ])
       );

--- a/src/fastify-metrics.ts
+++ b/src/fastify-metrics.ts
@@ -7,6 +7,7 @@ import {
 import promClient, {
   Histogram,
   LabelValues,
+  PrometheusContentType,
   Registry,
   Summary,
 } from 'prom-client';
@@ -191,8 +192,10 @@ export class FastifyMetrics implements IFastifyMetrics {
       return [];
     }
     return [
-      ...(routeMetrics.overrides?.histogram?.registers ?? []),
-      ...(routeMetrics.overrides?.summary?.registers ?? []),
+      ...((routeMetrics.overrides?.histogram?.registers ??
+        []) as Registry<PrometheusContentType>[]),
+      ...((routeMetrics.overrides?.summary?.registers ??
+        []) as Registry<PrometheusContentType>[]),
     ];
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,7 @@ export interface IMetricsRouteContextConfig {
  * @see {@link https://github.com/siimon/prom-client#default-metrics | prom-client} for extra options
  */
 export interface IDefaultMetricsConfig
-  extends DefaultMetricsCollectorConfiguration {
+  extends DefaultMetricsCollectorConfiguration<'text/plain; version=0.0.4; charset=utf-8'> {
   /**
    * Enables collection of default prom-client metrics (e.g. node.js vitals like
    * cpu, memory, etc.)


### PR DESCRIPTION
BREAKING CHANGE: this drops support for node v16 as prom-client also dropped support for node 16.

Node 16 is out of support since 11 Sep 2023.

prom-client adds support for opentelemetry. This PR just changes all code so that it works the same as before. Maybe opentelemetry support as requested in #82 should not be a big problem anymore.