### PR TITLE
feat!: migrate from prom-client to @prometheus-io/client

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 [Prometheus](https://prometheus.io/) metrics exporter for Fastify.
 
-This plugin uses [prom-client](https://github.com/siimon/prom-client) under the hood with optional support for [@platformatic/prom-client](https://github.com/platformatic/prom-client) as a high-performance drop-in replacement.
+This plugin uses [@prometheus-io/client](https://github.com/prometheus/client_js) under the hood with optional support for [@platformatic/prom-client](https://github.com/platformatic/prom-client) as a high-performance drop-in replacement.
 
 This plugin also adds two http metrics for your routes:
 
@@ -26,6 +26,7 @@ This plugin also adds two http metrics for your routes:
   - [ToC](#toc)
   - [Fastify support](#fastify-support)
   - [Notable changes](#notable-changes)
+    - [v14.x.x](#v14xx)
     - [v12.x.x](#v12xx)
     - [v11.x.x](#v11xx)
     - [v10.x.x](#v10xx)
@@ -58,8 +59,16 @@ This plugin also adds two http metrics for your routes:
 - **v9.x.x** - supports `fastify-4.x` `prom-client-14.x`
 - **v11.x.x** - supports `fastify-4.x` `prom-client-15.x`
 - **v12.x.x** - supports `fastify-5.x` `prom-client-15.x`
+- **v14.x.x** - supports `fastify-5.x` `@prometheus-io/client-0.16.x`
 
 ## Notable changes
+
+### v14.x.x
+
+- Replace the deprecated `prom-client` dependency with its official successor
+  [@prometheus-io/client](https://github.com/prometheus/client_js), now maintained by the
+  Prometheus team.
+- Drop node.js 20 support. `@prometheus-io/client` requires node.js `>=22`.
 
 ### v12.x.x
 
@@ -106,19 +115,19 @@ pnpm i fastify-metrics --save
 
 ## Using @platformatic/prom-client
 
-This plugin supports [@platformatic/prom-client](https://github.com/platformatic/prom-client) as an optional drop-in replacement for `prom-client`. It is a performance-focused fork by [Platformatic](https://platformatic.dev/) that provides the same API with lower overhead — optimized internal data structures, reduced memory allocations, and faster metric serialization.
+This plugin supports [@platformatic/prom-client](https://github.com/platformatic/prom-client) as an optional drop-in replacement for `@prometheus-io/client`. It is a performance-focused fork by [Platformatic](https://platformatic.dev/) that provides the same API with lower overhead — optimized internal data structures, reduced memory allocations, and faster metric serialization.
 
-**If `@platformatic/prom-client` is installed, the plugin will use it automatically.** No configuration changes needed. If it's not installed, the plugin falls back to standard `prom-client`.
+**If `@platformatic/prom-client` is installed, the plugin will use it automatically.** No configuration changes needed. If it's not installed, the plugin falls back to `@prometheus-io/client`.
 
 ### Why use it
 
-| | `prom-client` | `@platformatic/prom-client` |
+| | `@prometheus-io/client` | `@platformatic/prom-client` |
 |---|---|---|
 | **API** | Standard | Same (drop-in compatible) |
 | **Internal storage** | `hashMap` | Optimized `LabelMap` |
 | **Memory allocations** | Standard | Reduced |
 | **Metric serialization** | Standard | Faster |
-| **Node.js support** | >=16 | ^20 \|\| ^22 \|\| >=24 |
+| **Node.js support** | ^22 \|\| ^24 \|\| >=26 | ^20 \|\| ^22 \|\| >=24 |
 
 ### Installation
 
@@ -149,25 +158,25 @@ await app.register(metricsPlugin, {
 
 ### Verifying which client is active
 
-After registration, `fastify.metrics.client` holds the resolved prom-client instance. You can check which one is being used:
+After registration, `fastify.metrics.client` holds the resolved prometheus client instance. You can check which one is being used:
 
 ```js
 await app.ready();
-console.log(app.metrics.client); // the active prom-client module
+console.log(app.metrics.client); // the active prometheus client module
 ```
 
 <sub>[Back to top](#toc)</sub>
 
 ## Features and requirements
 
-- Collects default server metrics (see [prom-client](https://github.com/siimon/prom-client/tree/master/lib/metrics));
+- Collects default server metrics (see [@prometheus-io/client](https://github.com/prometheus/client_js/tree/master/lib/metrics));
 - Collects route response timings
 - Adds `metrics` to fastify instance for your custom metrics.
 
 ---
 
 - Requires fastify `>=4.0.0`.
-- Node.js `>=20.0.0`.
+- Node.js `>=22.0.0`.
 
 <sub>[Back to top](#toc)</sub>
 
@@ -203,7 +212,7 @@ See for details [docs](docs/api/fastify-metrics.imetricspluginoptions.md)
 | [defaultMetrics?](./docs/api/fastify-metrics.imetricspluginoptions.defaultmetrics.md)                 | [IDefaultMetricsConfig](./docs/api/fastify-metrics.idefaultmetricsconfig.md)                                        | `{ enabled: true }` |
 | [endpoint?](./docs/api/fastify-metrics.imetricspluginoptions.endpoint.md)                             | string \| null \| [`Fastify.RouteOptions`](https://www.fastify.io/docs/api/latest/Reference/Routes/#routes-options) | `'/metrics'`        |
 | [name?](./docs/api/fastify-metrics.imetricspluginoptions.name.md)                                     | string                                                                                                              | `'metrics'`         |
-| [promClient?](./docs/api/fastify-metrics.imetricspluginoptions.promclient.md)                         | `prom-client` instance \| null                                                                                      | `null`              |
+| [promClient?](./docs/api/fastify-metrics.imetricspluginoptions.promclient.md)                         | `@prometheus-io/client` instance \| null                                                                            | `null`              |
 | [routeMetrics?](./docs/api/fastify-metrics.imetricspluginoptions.routemetrics.md)                     | [IRouteMetricsConfig](./docs/api/fastify-metrics.iroutemetricsconfig.md)                                            | `{ enabled: true }` |
 
 #### Route metrics

--- a/docs/api/fastify-metrics.idefaultmetricsconfig.enabled.md
+++ b/docs/api/fastify-metrics.idefaultmetricsconfig.enabled.md
@@ -4,7 +4,7 @@
 
 ## IDefaultMetricsConfig.enabled property
 
-Enables collection of default prom-client metrics (e.g. node.js vitals like cpu, memory, etc.)
+Enables collection of default prometheus client metrics (e.g. node.js vitals like cpu, memory, etc.)
 
 **Signature:**
 

--- a/docs/api/fastify-metrics.idefaultmetricsconfig.md
+++ b/docs/api/fastify-metrics.idefaultmetricsconfig.md
@@ -4,7 +4,7 @@
 
 ## IDefaultMetricsConfig interface
 
-Default prom-client metrics config
+Default prometheus client metrics config
 
 **Signature:**
 
@@ -15,7 +15,7 @@ export interface IDefaultMetricsConfig extends DefaultMetricsCollectorConfigurat
 
 ## Remarks
 
-Extends the [prom-client](https://github.com/siimon/prom-client#default-metrics) interface. So it accepts all options from it and pass to default metrics.
+Extends the [@prometheus-io/client](https://github.com/prometheus/client_js#default-metrics) interface. So it accepts all options from it and pass to default metrics.
 
 ## Properties
 
@@ -55,7 +55,7 @@ boolean
 
 </td><td>
 
-Enables collection of default prom-client metrics (e.g. node.js vitals like cpu, memory, etc.)
+Enables collection of default prometheus client metrics (e.g. node.js vitals like cpu, memory, etc.)
 
 
 </td></tr>

--- a/docs/api/fastify-metrics.ifastifymetrics.client.md
+++ b/docs/api/fastify-metrics.ifastifymetrics.client.md
@@ -4,7 +4,7 @@
 
 ## IFastifyMetrics.client property
 
-Prom-client instance
+Prometheus client instance
 
 **Signature:**
 

--- a/docs/api/fastify-metrics.ifastifymetrics.md
+++ b/docs/api/fastify-metrics.ifastifymetrics.md
@@ -50,7 +50,7 @@ typeof client
 
 </td><td>
 
-Prom-client instance
+Prometheus client instance
 
 
 </td></tr>

--- a/docs/api/fastify-metrics.imetricspluginoptions.clearregisteroninit.md
+++ b/docs/api/fastify-metrics.imetricspluginoptions.clearregisteroninit.md
@@ -4,7 +4,7 @@
 
 ## IMetricsPluginOptions.clearRegisterOnInit property
 
-Clears the prom-client global registry before adding metrics. Default to `false`
+Clears the prometheus client global registry before adding metrics. Default to `false`
 
 **Signature:**
 

--- a/docs/api/fastify-metrics.imetricspluginoptions.defaultmetrics.md
+++ b/docs/api/fastify-metrics.imetricspluginoptions.defaultmetrics.md
@@ -4,7 +4,7 @@
 
 ## IMetricsPluginOptions.defaultMetrics property
 
-Default prom-client metrics config. Collect prometheus recommended and node.js specific metrics like event loop lag.
+Default prometheus client metrics config. Collect prometheus recommended and node.js specific metrics like event loop lag.
 
 **Signature:**
 

--- a/docs/api/fastify-metrics.imetricspluginoptions.md
+++ b/docs/api/fastify-metrics.imetricspluginoptions.md
@@ -50,7 +50,7 @@ boolean
 
 </td><td>
 
-Clears the prom-client global registry before adding metrics. Default to `false`
+Clears the prometheus client global registry before adding metrics. Default to `false`
 
 
 </td></tr>
@@ -69,7 +69,7 @@ Clears the prom-client global registry before adding metrics. Default to `false`
 
 </td><td>
 
-Default prom-client metrics config. Collect prometheus recommended and node.js specific metrics like event loop lag.
+Default prometheus client metrics config. Collect prometheus recommended and node.js specific metrics like event loop lag.
 
 
 </td></tr>

--- a/docs/api/fastify-metrics.md
+++ b/docs/api/fastify-metrics.md
@@ -4,7 +4,7 @@
 
 ## fastify-metrics package
 
-Prometheus metrics exporter for Fastify. Based on [prom-client](https://github.com/siimon/prom-client)<!-- -->. Also by default it adds fastify route response time metrics (histogram and summary).
+Prometheus metrics exporter for Fastify. Based on [@prometheus-io/client](https://github.com/prometheus/client_js)<!-- -->. Also by default it adds fastify route response time metrics (histogram and summary).
 
 ## Interfaces
 
@@ -23,7 +23,7 @@ Description
 
 </td><td>
 
-Default prom-client metrics config
+Default prometheus client metrics config
 
 </td></tr>
 <tr><td>

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -24,7 +24,7 @@ Description
 
 </td><td>
 
-Prometheus metrics exporter for Fastify. Based on [prom-client](https://github.com/siimon/prom-client)<!-- -->. Also by default it adds fastify route response time metrics (histogram and summary).
+Prometheus metrics exporter for Fastify. Based on [@prometheus-io/client](https://github.com/prometheus/client_js)<!-- -->. Also by default it adds fastify route response time metrics (histogram and summary).
 
 
 </td></tr>

--- a/etc/fastify-metrics.api.md
+++ b/etc/fastify-metrics.api.md
@@ -4,18 +4,18 @@
 
 ```ts
 
-import type client from 'prom-client';
-import type { DefaultMetricsCollectorConfiguration } from 'prom-client';
+import type client from '@prometheus-io/client';
+import type { DefaultMetricsCollectorConfiguration } from '@prometheus-io/client';
 import { FastifyBaseLogger } from 'fastify';
 import { FastifyPluginCallback } from 'fastify';
 import type { FastifyReply } from 'fastify';
 import type { FastifyRequest } from 'fastify';
 import { FastifyTypeProviderDefault } from 'fastify';
-import type { HistogramConfiguration } from 'prom-client';
+import type { HistogramConfiguration } from '@prometheus-io/client';
 import type { HTTPMethods } from 'fastify';
 import { RawServerDefault } from 'fastify';
 import type { RouteOptions } from 'fastify';
-import type { SummaryConfiguration } from 'prom-client';
+import type { SummaryConfiguration } from '@prometheus-io/client';
 
 // @public
 const _default: FastifyPluginCallback<Partial<IMetricsPluginOptions>, RawServerDefault, FastifyTypeProviderDefault, FastifyBaseLogger>;

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "test:unit:local": "node --no-warnings --import tsx --experimental-test-coverage --test test/** --test-coverage-exclude=test/**"
   },
   "dependencies": {
-    "fastify-plugin": "^6.0.0",
-    "prom-client": "^15.1.3"
+    "@prometheus-io/client": "^0.16.1",
+    "fastify-plugin": "^6.0.0"
   },
   "devDependencies": {
     "@microsoft/api-documenter": "^7.29.8",
@@ -83,13 +83,13 @@
   },
   "packageManager": "pnpm@10.32.1",
   "engines": {
-    "node": ">=20",
+    "node": ">=22",
     "pnpm": ">=10"
   },
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": ">=20"
+      "version": ">=22"
     }
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,12 @@ importers:
       '@platformatic/prom-client':
         specifier: ^1.0.0
         version: 1.0.0
+      '@prometheus-io/client':
+        specifier: ^0.16.1
+        version: 0.16.1
       fastify-plugin:
         specifier: ^6.0.0
         version: 6.0.0
-      prom-client:
-        specifier: ^15.1.3
-        version: 15.1.3
     devDependencies:
       '@microsoft/api-documenter':
         specifier: ^7.29.8
@@ -533,6 +533,10 @@ packages:
     resolution: {integrity: sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==}
     engines: {node: '>=12'}
 
+  '@prometheus-io/client@0.16.1':
+    resolution: {integrity: sha512-XkFPsGFGoSs/UMg/vh0QLDpanl/tsrOV5PLHdpGe8Ho+ir/Llhytr15j6y8ZwLrpIGzK9gTVVpIalA6C4UjUZw==}
+    engines: {node: ^22 || ^24 || >=26}
+
   '@reteps/dockerfmt@0.5.2':
     resolution: {integrity: sha512-Hbr7yen4fP5TxGM54ucXa4o5NwWXatJ6Bd9I8gp0PValYbI4Rug2Gu+rVv7K7o/efQc3F5ctqWJz47rYaa8zBw==}
     engines: {node: ^v12.20.0 || ^14.13.0 || >=16.0.0}
@@ -584,10 +588,6 @@ packages:
     engines: {node: '>=20.8.1'}
     peerDependencies:
       semantic-release: '>=20.1.0'
-
-  '@semantic-release/error@3.0.0':
-    resolution: {integrity: sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==}
-    engines: {node: '>=14.17'}
 
   '@semantic-release/error@4.0.0':
     resolution: {integrity: sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==}
@@ -1836,9 +1836,6 @@ packages:
   lodash.uniqby@4.7.0:
     resolution: {integrity: sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
-
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -2313,11 +2310,6 @@ packages:
 
   process-warning@5.1.0:
     resolution: {integrity: sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==}
-
-  prom-client@15.1.3:
-    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
-    engines: {node: ^16 || ^18 || >=20}
-    deprecated: prom-client has been replaced by @prometheus-io/client
 
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
@@ -3270,6 +3262,11 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
+  '@prometheus-io/client@0.16.1':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.2
+
   '@reteps/dockerfmt@0.5.2': {}
 
   '@rushstack/node-core-library@5.24.0(@types/node@25.9.3)':
@@ -3333,8 +3330,6 @@ snapshots:
       semantic-release: 25.0.9(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
-
-  '@semantic-release/error@3.0.0': {}
 
   '@semantic-release/error@4.0.0': {}
 
@@ -4663,8 +4658,6 @@ snapshots:
 
   lodash.uniqby@4.7.0: {}
 
-  lodash@4.17.23: {}
-
   lru-cache@10.4.3: {}
 
   lru-cache@11.5.2: {}
@@ -5124,11 +5117,6 @@ snapshots:
   process-warning@4.0.1: {}
 
   process-warning@5.1.0: {}
-
-  prom-client@15.1.3:
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      tdigest: 0.1.2
 
   proto-list@1.2.4: {}
 

--- a/src/fastify-metrics.ts
+++ b/src/fastify-metrics.ts
@@ -1,15 +1,15 @@
+import promClient, {
+  type Histogram,
+  type LabelValues,
+  type Registry,
+  type Summary,
+} from '@prometheus-io/client';
 import type {
   FastifyInstance,
   FastifyReply,
   FastifyRequest,
   RouteOptions,
 } from 'fastify';
-import promClient, {
-  type Histogram,
-  type LabelValues,
-  type Registry,
-  type Summary,
-} from 'prom-client';
 import type { IFastifyMetrics, IMetricsPluginOptions } from './types';
 
 /**
@@ -32,8 +32,8 @@ interface IReqMetrics<T extends string> {
 }
 
 interface IRouteMetrics {
-  routeHist: Histogram;
-  routeSum: Summary;
+  routeHist: Histogram<string>;
+  routeSum: Summary<string>;
   labelNames: { method: string; status: string; route: string };
 }
 
@@ -80,7 +80,7 @@ export class FastifyMetrics implements IFastifyMetrics {
 
   private createTimers: (request: FastifyRequest) => void;
 
-  /** Prom-client instance. */
+  /** Prometheus client instance. */
   public readonly client: typeof promClient;
 
   /** Creates metrics collector instance */
@@ -251,7 +251,7 @@ export class FastifyMetrics implements IFastifyMetrics {
     this.deps.fastify.route(routeOptions);
   }
 
-  /** Collect default prom-client metrics */
+  /** Collect default prometheus client metrics */
   private collectDefaultMetrics(): void {
     this.deps.client.collectDefaultMetrics({
       ...this.options.defaultMetrics,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 /**
  * Prometheus metrics exporter for Fastify. Based on
- * {@link https://github.com/siimon/prom-client | prom-client}. Also by default
- * it adds fastify route response time metrics (histogram and summary).
+ * {@link https://github.com/prometheus/client_js | @prometheus-io/client}. Also
+ * by default it adds fastify route response time metrics (histogram and
+ * summary).
  *
  * @packageDocumentation
  */

--- a/src/resolve-client.ts
+++ b/src/resolve-client.ts
@@ -1,9 +1,9 @@
-import defaultClient from 'prom-client';
+import defaultClient from '@prometheus-io/client';
 
 /**
- * Resolves the prom-client implementation to use.
+ * Resolves the prometheus client implementation to use.
  * Prefers `@platformatic/prom-client` if installed (better performance),
- * falls back to `prom-client`.
+ * falls back to `@prometheus-io/client`.
  * @internal
  */
 export async function resolveClient(): Promise<typeof defaultClient> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,15 +1,15 @@
 import type {
+  DefaultMetricsCollectorConfiguration,
+  HistogramConfiguration,
+  SummaryConfiguration,
+} from '@prometheus-io/client';
+import type client from '@prometheus-io/client';
+import type {
   FastifyReply,
   FastifyRequest,
   HTTPMethods,
   RouteOptions,
 } from 'fastify';
-import type {
-  DefaultMetricsCollectorConfiguration,
-  HistogramConfiguration,
-  SummaryConfiguration,
-} from 'prom-client';
-import type client from 'prom-client';
 
 /**
  * Route config for metrics
@@ -24,19 +24,19 @@ export interface IMetricsRouteContextConfig {
 }
 
 /**
- * Default prom-client metrics config
+ * Default prometheus client metrics config
  *
  * @remarks
  * Extends the
- * {@link https://github.com/siimon/prom-client#default-metrics | prom-client}
+ * {@link https://github.com/prometheus/client_js#default-metrics | @prometheus-io/client}
  * interface. So it accepts all options from it and pass to default metrics.
  * @public
- * @see {@link https://github.com/siimon/prom-client#default-metrics | prom-client} for extra options
+ * @see {@link https://github.com/prometheus/client_js#default-metrics | @prometheus-io/client} for extra options
  */
 export interface IDefaultMetricsConfig extends DefaultMetricsCollectorConfiguration<'text/plain; version=0.0.4; charset=utf-8'> {
   /**
-   * Enables collection of default prom-client metrics (e.g. node.js vitals like
-   * cpu, memory, etc.)
+   * Enables collection of default prometheus client metrics (e.g. node.js
+   * vitals like cpu, memory, etc.)
    *
    * @defaultValue `true`
    */
@@ -272,8 +272,8 @@ export interface IMetricsPluginOptions {
   name: string;
 
   /**
-   * Default prom-client metrics config. Collect prometheus recommended and
-   * node.js specific metrics like event loop lag.
+   * Default prometheus client metrics config. Collect prometheus recommended
+   * and node.js specific metrics like event loop lag.
    *
    * @defaultValue `{ enabled: true }`
    */
@@ -287,8 +287,8 @@ export interface IMetricsPluginOptions {
   routeMetrics: IRouteMetricsConfig;
 
   /**
-   * Clears the prom-client global registry before adding metrics. Default to
-   * `false`
+   * Clears the prometheus client global registry before adding metrics.
+   * Default to `false`
    *
    * @defaultValue `false`
    */
@@ -301,7 +301,7 @@ export interface IMetricsPluginOptions {
  * @public
  */
 export interface IFastifyMetrics {
-  /** Prom-client instance */
+  /** Prometheus client instance */
   client: typeof client;
   /**
    * Initialize metrics in registries. Useful if you call `registry.clear()` to

--- a/test/clear-register.spec.ts
+++ b/test/clear-register.spec.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { after, afterEach, before, describe, it } from 'node:test';
+import type promClient from '@prometheus-io/client';
 import { fastify } from 'fastify';
-import type promClient from 'prom-client';
 import fastifyPlugin from '../src/index';
 import { clientPromise } from './helper';
 

--- a/test/default-metrics.spec.ts
+++ b/test/default-metrics.spec.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { afterEach, before, beforeEach, describe, it } from 'node:test';
+import type promClient from '@prometheus-io/client';
 import { fastify } from 'fastify';
-import type promClient from 'prom-client';
 import fastifyPlugin from '../src/index';
 import { clientPromise } from './helper';
 

--- a/test/edge-cases.spec.ts
+++ b/test/edge-cases.spec.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { after, afterEach, before, describe, it } from 'node:test';
+import type promClient from '@prometheus-io/client';
 import { fastify } from 'fastify';
-import type promClient from 'prom-client';
 import fastifyPlugin from '../src/index';
 import { clientPromise } from './helper';
 

--- a/test/endpoint-object.spec.ts
+++ b/test/endpoint-object.spec.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
+import type promClient from '@prometheus-io/client';
 import { fastify, type RouteOptions } from 'fastify';
-import type promClient from 'prom-client';
 import fastifyPlugin from '../src/index';
 import { clientPromise } from './helper';
 

--- a/test/exports.spec.ts
+++ b/test/exports.spec.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { after, afterEach, before, describe, it } from 'node:test';
+import type promClient from '@prometheus-io/client';
 import { fastify } from 'fastify';
-import type promClient from 'prom-client';
 import fastifyPlugin from '../src/index';
 import { clientPromise } from './helper';
 

--- a/test/inject-prom-client.spec.ts
+++ b/test/inject-prom-client.spec.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { afterEach, describe, it } from 'node:test';
+import type promClient from '@prometheus-io/client';
 import { fastify } from 'fastify';
-import type promClient from 'prom-client';
 import fastifyPlugin from '../src/index.js';
 
 void describe('metrics plugin', () => {

--- a/test/resolve-client.spec.ts
+++ b/test/resolve-client.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import defaultClient from 'prom-client';
+import defaultClient from '@prometheus-io/client';
 import { resolveClient } from '../src/resolve-client';
 
 void describe('resolveClient', () => {

--- a/test/route-metrics.spec.ts
+++ b/test/route-metrics.spec.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { afterEach, before, beforeEach, describe, it } from 'node:test';
+import type promClient from '@prometheus-io/client';
 import { fastify, type FastifyRequest } from 'fastify';
-import type promClient from 'prom-client';
 import fastifyPlugin from '../src/index';
 import { clientPromise } from './helper';
 


### PR DESCRIPTION
## What

Replaces the deprecated `prom-client` dependency with [`@prometheus-io/client`](https://github.com/prometheus/client_js), its official successor maintained by the Prometheus team.

npm marks `prom-client@15.1.3` as deprecated with the message `prom-client has been replaced by @prometheus-io/client`. The new package lives at `prometheus/client_js`, keeps the same original author, and exposes the same API surface, so this is largely a dependency and import swap.

## Changes

- `dependencies`: `prom-client@^15.1.3` -> `@prometheus-io/client@^0.16.1`
- Import specifiers updated across `src/` and `test/`
- `engines.node` and `devEngines`: `>=20` -> `>=22`, since `@prometheus-io/client` declares `^22 || ^24 || >=26`
- `IRouteMetrics` now types the route metrics as `Histogram<string>` / `Summary<string>`
- README, TSDoc comments, generated API docs and the api-extractor report updated

`@platformatic/prom-client` support is unchanged. It is still auto-detected and preferred when installed, with `@prometheus-io/client` as the fallback.

## Note on the type change

`@prometheus-io/client` narrowed `LabelValues` for label-less metrics:

```ts
type LabelValues<T extends string> = T extends NoLabelNameType
  ? Partial<Record<string, never>>
  : Partial<Record<T, string | number>>;
```

`IRouteMetrics` declared bare `Histogram` / `Summary`, which default to `NoLabelNameType` (`never`). The route metrics are actually created with string label names, so `startTimer()` no longer type-checked against `IReqMetrics<string>`. Annotating them as `Histogram<string>` / `Summary<string>` matches how they are constructed and fixes the six resulting `TS2322` errors. No runtime behaviour changes.

## Node.js bump

`@prometheus-io/client` requires node.js `>=22`, so node.js 20 support is dropped. CI already only tested `22.x` and `24.x`, so this aligns the declared range with what was actually being verified. `>=22` is used rather than mirroring the dependency's `^22 || ^24 || >=26` to stay consistent with the existing single-lower-bound style.
